### PR TITLE
added stack navigation with Auth navigation and a welcome screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,16 +3,23 @@ import { NavigationContainer } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { ThemeProvider } from 'styled-components'
 import { theme } from 'src/styles/theme'
+import AuthNavigator from 'src/navigators/Auth'
 
 const { Screen, Navigator } = createNativeStackNavigator()
 
 export default function App() {
+  const authenticated = false
+
   return (
     <ThemeProvider theme={theme}>
       <NavigationContainer>
-        <Navigator>
-          <Screen name="Home" component={Home} />
-        </Navigator>
+        {authenticated ? (
+          <Navigator>
+            <Screen name="Home" component={Home} />
+          </Navigator>
+        ) : (
+          <AuthNavigator />
+        )}
       </NavigationContainer>
     </ThemeProvider>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-native-async-storage/async-storage": "^1.17.11",
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
+        "@react-navigation/stack": "^6.3.16",
         "@supabase/supabase-js": "^2.8.0",
         "@types/react": "~18.0.27",
         "expo": "~48.0.4",
@@ -1793,6 +1794,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -4890,6 +4903,52 @@
         "nanoid": "^3.1.23"
       }
     },
+    "node_modules/@react-navigation/stack": {
+      "version": "6.3.16",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-6.3.16.tgz",
+      "integrity": "sha512-KTOn9cNuZ6p154Htbl2DiR95Wl+c7niLPRiGs7gjOkyVDGiaGQF9ODNQTYBDE1OxZGHe/EyYc6T2CbmiItLWDg==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.17",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 1.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
+    "node_modules/@react-navigation/stack/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/@react-navigation/stack/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@react-navigation/stack/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -4991,6 +5050,12 @@
         "@supabase/storage-js": "^2.1.0",
         "cross-fetch": "^3.1.5"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.41",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
+      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==",
+      "peer": true
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -11860,6 +11925,23 @@
       "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
+      "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
+      "peer": true,
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-gradle-plugin": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
+    "@react-navigation/stack": "^6.3.16",
     "@supabase/supabase-js": "^2.8.0",
     "@types/react": "~18.0.27",
     "expo": "~48.0.4",

--- a/src/navigators/Auth.tsx
+++ b/src/navigators/Auth.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { createStackNavigator } from '@react-navigation/stack'
+import { Welcome } from 'src/pages/Auth/Welcome'
+
+const { Navigator, Screen } = createStackNavigator()
+
+const AuthNavigator = () => {
+  return (
+    <Navigator>
+      <Screen name="Welcome" component={Welcome} />
+    </Navigator>
+  )
+}
+
+export default AuthNavigator

--- a/src/pages/Auth/Welcome.tsx
+++ b/src/pages/Auth/Welcome.tsx
@@ -1,0 +1,3 @@
+export const Welcome = () => {
+  return <></>
+}


### PR DESCRIPTION
Overview / added stack navigation to able to create Stack screens and added auth navigation to add authentication screen into it with a mock authentication system on the app.tsx to able to simulate the authentication process

## Changes
- installed @react-navigation/stack package
- added navigators folder to add different navigators to the app
- added AuthNavigators to be able to add screens on the authentication flow
- added a welcome screen just to add a filler screen to the AuthNavigator
-  added a authenticated variable to simulate authentication
