### PR TITLE
Add/utils default theme

### DIFF
--- a/src/utils/defaultTheme.ts
+++ b/src/utils/defaultTheme.ts
@@ -1,0 +1,11 @@
+import { Appearance } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const defaultTheme = async () => {
+    
+    const preferedTheme = Appearance.getColorScheme() 
+
+    const savedTheme = await AsyncStorage.getItem("theme")
+
+    return preferedTheme || savedTheme;
+}


### PR DESCRIPTION
Overview / Description

Added new function `defaultTheme` in the `utils` folder.

## Changes
- Added `defaultTheme` function to get the preferred theme based on device appearance or the saved theme in AsyncStorage.


## Checklist
- [ ] Checked on iOS
- [ ] Checked on Android
