### PR TITLE
Add/style utils typography

### DIFF
--- a/src/styles/utils/typography/index.ts
+++ b/src/styles/utils/typography/index.ts
@@ -1,0 +1,39 @@
+import {
+  HeadingFontSize,
+  IHeadingProps,
+  IParagraphProps,
+  ParagraphFontSize,
+} from './typography.types'
+
+import { css } from 'styled-components'
+
+const primaryHeadingStyles = css`
+  font-weight: 700;
+  line-height: 120%;
+`
+
+export const generateHeading = ({ size, color }: IHeadingProps) => {
+  return css`
+    font-size: ${HeadingFontSize[size]};
+    ${primaryHeadingStyles};
+    color: ${color};
+  `
+}
+
+const primaryParagraphStyles = css`
+  line-height: 140%;
+  letter-spacing: 0.2px;
+`
+
+export const generateParagraph = ({
+  fontWeight,
+  size,
+  color,
+}: IParagraphProps) => {
+  return css`
+    font-weight: ${fontWeight};
+    font-size: ${ParagraphFontSize[size]};
+    color: ${color};
+    ${primaryParagraphStyles}
+  `
+}

--- a/src/styles/utils/typography/typography.types.ts
+++ b/src/styles/utils/typography/typography.types.ts
@@ -1,0 +1,29 @@
+import { CSSObject } from 'styled-components'
+
+export enum HeadingFontSize {
+  H1 = 48,
+  H2 = 40,
+  H3 = 32,
+  H4 = 24,
+  H5 = 20,
+  H6 = 18,
+}
+
+export interface IHeadingProps {
+  size: HeadingFontSize
+  color: string
+}
+
+export enum ParagraphFontSize {
+  xlarge = 18,
+  large = 16,
+  medium = 14,
+  small = 12,
+  xsmall = 10,
+}
+
+export interface IParagraphProps {
+  fontWeight: number
+  color: string
+  size: ParagraphFontSize
+}

--- a/src/utils/defaultTheme.ts
+++ b/src/utils/defaultTheme.ts
@@ -7,5 +7,5 @@ export const defaultTheme = async () => {
 
     const savedTheme = await AsyncStorage.getItem("theme")
 
-    return preferedTheme || savedTheme;
+    return savedTheme || preferedTheme;
 }


### PR DESCRIPTION
Overview / Description

This pull request adds new typography styles for headings and paragraphs.


## Changes
- Added a new file `typography.types.ts` to define enums for heading and paragraph font sizes, and interfaces for their respective props.
- Added `HeadingFontSize` enum with values for H1 through H6 sizes.
- Added `IParagraphProps` interface with `size`, `fontWeight`, and `color` props for paragraph styling.
- Added `ParagraphFontSize` enum with values for `xlarge`, `large`, `medium`, `small`, and `xsmall` sizes.
- Updated `index.ts` file to include functions `generateHeading` and `generateParagraph` for generating styles for headings and paragraphs based on props.
- Added `primaryHeadingStyles` and `primaryParagraphStyles` to define common styles for all headings and paragraphs.
- `generateHeading` function takes in an `IHeadingProps` object with `size` and `color` props, and generates styles for headings with the specified size and color.
- `generateParagraph` function takes in an `IParagraphProps` object with `size`, `fontWeight`, and `color` props, and generates styles for paragraphs with the specified size, weight, and color.
## Screenshots

(prefer animated gif)

N/A

## Checklist
- [ ] Checked on iOS
- [ ] Checked on Android
