### PR TITLE
fixed imports just showing src when trying to import instead of the f…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,24 +1,25 @@
 module.exports = {
     presets: ['babel-preset-expo'],
-    plugins: [
+    "plugins": [
         [
-            'module-resolver',
+            "module-resolver",
             {
-                root: ['./'],
-                alias: {
-                    'src': './src/',
-                },
-                extensions: [
-                    '.ios.js',
-                    '.android.js',
-                    '.js',
-                    '.jsx',
-                    '.json',
-                    '.tsx',
-                    '.ts',
-                    '.native.js',
+                "root": ["./src"],
+                "extensions": [
+                    ".ios.ts",
+                    ".android.ts",
+                    ".ts",
+                    ".ios.tsx",
+                    ".android.tsx",
+                    ".tsx",
+                    ".jsx",
+                    ".js",
+                    ".json"
                 ],
-            },
-        ],
-    ],
+                "alias": {
+                    "src": "./src/",
+                }
+            }
+        ]
+    ]
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": { "src": ["./src/*"] }
+    "baseUrl": "."
   },
   "exclude": ["node_modules"],
   "extends": "expo/tsconfig.base"


### PR DESCRIPTION
…ull import

Overview / Description

fixed aliased imports because imports gave just "src" instead of putting the correct path for the file/folder

## Changes
- fixed babel.config aliased imports 
- fixed tsconfig aliased imports and matched it with babel.config

## Checklist
- [ ] Checked on iOS
- [x] Checked on Android
